### PR TITLE
Fix Vercel deployment: Add configuration for app subdirectory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "cd app && npm run build",
+  "devCommand": "cd app && npm run dev",
+  "installCommand": "cd app && npm install",
+  "outputDirectory": "app/.next",
+  "framework": "nextjs",
+  "rootDirectory": "app"
+}


### PR DESCRIPTION
## Problem
Vercel deployment was failing with "No Next.js version detected" error because the Next.js application is located in the `app/` subdirectory, but Vercel was looking for `package.json` in the root directory.

## Solution
Added `vercel.json` configuration file to specify:
- Root directory is `app/`
- Build, dev, and install commands should run from the `app/` directory
- Output directory is `app/.next`
- Framework is Next.js

## Changes
- ✅ Added `vercel.json` with proper configuration
- ✅ Specifies `rootDirectory: "app"` to tell Vercel where the Next.js app is located
- ✅ Configures build commands to run from the correct directory

This should resolve the deployment issue and allow Vercel to properly detect and build the Next.js application.