### PR TITLE
Fix Vercel deployment: Add root package.json for Next.js detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "teams-file-organizer",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "app"
+  ],
+  "scripts": {
+    "dev": "cd app && npm run dev",
+    "build": "cd app && npm run build",
+    "start": "cd app && npm run start",
+    "lint": "cd app && npm run lint",
+    "install-deps": "npm install && cd app && npm install"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
+  "dependencies": {
+    "next": "14.2.28",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.6.2",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
+    "typescript": "5.2.2"
+  },
+  "description": "Teams File Organizer - A Next.js application for organizing team files",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lrferris2003/teams-file-organizer.git"
+  },
+  "keywords": [
+    "nextjs",
+    "react",
+    "teams",
+    "file-organizer",
+    "typescript"
+  ]
+}


### PR DESCRIPTION
## Problem
Vercel deployment was failing because Next.js wasn't detected in the root `package.json`. The Next.js application is located in the `app/` subdirectory, but Vercel requires Next.js dependencies to be present at the root level for proper detection.

## Solution
This PR adds a root-level `package.json` that:

- ✅ **Enables Next.js detection** by including `next`, `react`, and `react-dom` dependencies at the root level
- ✅ **Uses workspaces** to properly manage the `app/` subdirectory as a workspace
- ✅ **Delegates build commands** to the actual Next.js app in the `app/` directory
- ✅ **Maintains existing structure** without moving any files
- ✅ **Includes proper metadata** for the repository

## Key Features
- **Workspace Configuration**: Uses npm workspaces to manage the `app/` subdirectory
- **Script Delegation**: All npm scripts (`dev`, `build`, `start`, `lint`) properly delegate to the app directory
- **Vercel Compatibility**: Includes the essential Next.js dependencies that Vercel looks for
- **Node.js Version**: Specifies minimum Node.js 18+ requirement

## Testing
Once merged, this should allow Vercel to:
1. Detect the Next.js framework properly
2. Install dependencies correctly using the workspace configuration
3. Build and deploy the application successfully

The deployment should work immediately after merging this PR.